### PR TITLE
fix TConstruct item copy fixed #302

### DIFF
--- a/src/main/java/nightkosh/gravestone/core/event/EventsHandler.java
+++ b/src/main/java/nightkosh/gravestone/core/event/EventsHandler.java
@@ -1,6 +1,7 @@
 package nightkosh.gravestone.core.event;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.passive.*;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
@@ -18,6 +19,8 @@ import nightkosh.gravestone.core.logger.GravesLogger;
 import nightkosh.gravestone.helper.BackupsHelper;
 import nightkosh.gravestone.helper.GraveGenerationHelper;
 import nightkosh.gravestone.helper.api.APIGraveGeneration;
+
+import java.util.List;
 
 /**
  * GraveStone mod
@@ -96,6 +99,11 @@ public class EventsHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onPlayerDrops(PlayerDropsEvent event) {
+
+        if (event.isCanceled()) {
+            return;
+        }
+
         if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
             if (!Config.generateGravesInLava && event.getSource().damageType.equals("lava")) {
                 return;
@@ -110,7 +118,11 @@ public class EventsHandler {
                         }
                     }
 
-                    GraveGenerationHelper.createPlayerGrave(player, event.getDrops(), event.getSource(), MobHandler.getAndRemoveSpawnTime(player));
+                    List<EntityItem> drops = event.getDrops();
+                    if (GraveGenerationHelper.createPlayerGrave(player, drops, event.getSource(), MobHandler.getAndRemoveSpawnTime(player)))
+                    {
+                        drops.clear();
+                    }
                 }
             }
         }


### PR DESCRIPTION
fixed #302
balgros Posted Feb 5, 2019 #155
Whenever a Player dies on 1.12.2, his TConstruct Items spawns on the ground and in his grave. So it doubles it. Could you please fix this? I love your Mod.

maybe entityItem.setDead() fail